### PR TITLE
add 3 json v3 service testing fixtures

### DIFF
--- a/zerver/webhooks/pagerduty/fixtures/service_created_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/service_created_v3.json
@@ -1,0 +1,22 @@
+{
+  "event": {
+    "id": "01DFJKL2Q3MNOP4RSTUV5WXYZ1",
+    "event_type": "service.created",
+    "resource_type": "service",
+    "occurred_at": "2024-01-15T12:00:00.000Z",
+    "agent": {
+      "html_url": "https://pig208.pagerduty.com/users/PAGENT1",
+      "id": "PAGENT1",
+      "self": "https://api.pagerduty.com/users/PAGENT1",
+      "summary": "Admin User",
+      "type": "user_reference"
+    },
+    "data": {
+      "type": "service",
+      "id": "PSERVICE1",
+      "summary": "Test Service",
+      "self": "https://api.pagerduty.com/services/PSERVICE1",
+      "html_url": "https://pig208.pagerduty.com/services/PSERVICE1"
+    }
+  }
+}

--- a/zerver/webhooks/pagerduty/fixtures/service_deleted_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/service_deleted_v3.json
@@ -1,0 +1,22 @@
+{
+  "event": {
+    "id": "01DFJKL2Q3MNOP4RSTUV5WXYZ3",
+    "event_type": "service.deleted",
+    "resource_type": "service",
+    "occurred_at": "2024-01-15T12:00:00.000Z",
+    "agent": {
+      "html_url": "https://pig208.pagerduty.com/users/PAGENT1",
+      "id": "PAGENT1",
+      "self": "https://api.pagerduty.com/users/PAGENT1",
+      "summary": "Admin User",
+      "type": "user_reference"
+    },
+    "data": {
+      "type": "service",
+      "id": "PSERVICE1",
+      "summary": "Test Service",
+      "self": "https://api.pagerduty.com/services/PSERVICE1",
+      "html_url": "https://pig208.pagerduty.com/services/PSERVICE1"
+    }
+  }
+}

--- a/zerver/webhooks/pagerduty/fixtures/service_updated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/service_updated_v3.json
@@ -1,0 +1,22 @@
+{
+  "event": {
+    "id": "01DFJKL2Q3MNOP4RSTUV5WXYZ2",
+    "event_type": "service.updated",
+    "resource_type": "service",
+    "occurred_at": "2024-01-15T12:00:00.000Z",
+    "agent": {
+      "html_url": "https://pig208.pagerduty.com/users/PAGENT1",
+      "id": "PAGENT1",
+      "self": "https://api.pagerduty.com/users/PAGENT1",
+      "summary": "Admin User",
+      "type": "user_reference"
+    },
+    "data": {
+      "type": "service",
+      "id": "PSERVICE1",
+      "summary": "Test Service",
+      "self": "https://api.pagerduty.com/services/PSERVICE1",
+      "html_url": "https://pig208.pagerduty.com/services/PSERVICE1"
+    }
+  }
+}


### PR DESCRIPTION

Add test fixtures containing example webhook payloads for three
PagerDuty V3 service events: service.created, service.updated,
and service.deleted.

service.created: Example webhook sent when a service is created
- service.updated: Example webhook sent when a service is modified
- service.deleted: Example webhook sent when a service is removed

These fixtures match PagerDuty's V3 webhook format with service-specific
data structure (uses 'summary' field, includes 'type: service', and
references service IDs instead of incident IDs).